### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/io/bxbxbai/zhuanlan/core/ZhuanLanApi.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/core/ZhuanLanApi.java
@@ -35,6 +35,8 @@ public final class ZhuanLanApi {
 
 
     public static final class Url {
+        private Url() {}
+
         public static final String ZHIHU_DAILY_BEFORE = "http://news.at.zhihu.com/api/3/news/before/";
         public static final String ZHIHU_DAILY_OFFLINE_NEWS = "http://news-at.zhihu.com/api/3/news/";
         public static final String ZHIHU_DAILY_PURIFY_HEROKU_BEFORE = "http://zhihu-daily-purify.herokuapp.com/raw/";

--- a/app/src/main/java/io/bxbxbai/zhuanlan/utils/FastBlur.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/utils/FastBlur.java
@@ -7,6 +7,8 @@ import android.graphics.Bitmap;
  */
 public class FastBlur {
 
+    private FastBlur() {}
+
     public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap) {
 
         // Stack Blur v1.0 from

--- a/app/src/main/java/io/bxbxbai/zhuanlan/utils/Utils.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/utils/Utils.java
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class Utils {
 
+    private Utils() {}
+
     private static final int MINUTE = 60;
     private static final int HOUR = MINUTE * 60;
     private static final int DAY = HOUR * 24;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed