### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/app/src/main/java/io/bxbxbai/zhuanlan/bean/Author.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/bean/Author.java
@@ -45,6 +45,28 @@ public class Author implements Parcelable {
     @SerializedName(NAME)
     private String name;
 
+    public static final Parcelable.Creator<Author> CREATOR = new Parcelable.Creator<Author>() {
+        public Author createFromParcel(Parcel source) {
+            return new Author(source);
+        }
+
+        public Author[] newArray(int size) {
+            return new Author[size];
+        }
+    };
+
+    public Author() {
+    }
+
+    private Author(Parcel in) {
+        this.bio = in.readString();
+        this.hash = in.readString();
+        this.description = in.readString();
+        this.profileUrl = in.readString();
+        this.avatar = in.readParcelable(Avatar.class.getClassLoader());
+        this.slug = in.readString();
+        this.name = in.readString();
+    }
 
     public String getBio() {
         return bio;
@@ -117,27 +139,4 @@ public class Author implements Parcelable {
         dest.writeString(this.slug);
         dest.writeString(this.name);
     }
-
-    public Author() {
-    }
-
-    private Author(Parcel in) {
-        this.bio = in.readString();
-        this.hash = in.readString();
-        this.description = in.readString();
-        this.profileUrl = in.readString();
-        this.avatar = in.readParcelable(Avatar.class.getClassLoader());
-        this.slug = in.readString();
-        this.name = in.readString();
-    }
-
-    public static final Parcelable.Creator<Author> CREATOR = new Parcelable.Creator<Author>() {
-        public Author createFromParcel(Parcel source) {
-            return new Author(source);
-        }
-
-        public Author[] newArray(int size) {
-            return new Author[size];
-        }
-    };
 }

--- a/app/src/main/java/io/bxbxbai/zhuanlan/bean/Avatar.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/bean/Avatar.java
@@ -20,6 +20,25 @@ public class Avatar implements Parcelable {
     @SerializedName(TEMPLATE)
     private String template;
 
+
+    public static final Parcelable.Creator<Avatar> CREATOR = new Parcelable.Creator<Avatar>() {
+        public Avatar createFromParcel(Parcel source) {
+            return new Avatar(source);
+        }
+
+        public Avatar[] newArray(int size) {
+            return new Avatar[size];
+        }
+    };
+
+    public Avatar() {
+    }
+
+    private Avatar(Parcel in) {
+        this.id = in.readString();
+        this.template = in.readString();
+    }
+
     public String getId() {
         return id;
     }
@@ -47,21 +66,4 @@ public class Avatar implements Parcelable {
         dest.writeString(this.template);
     }
 
-    public Avatar() {
-    }
-
-    private Avatar(Parcel in) {
-        this.id = in.readString();
-        this.template = in.readString();
-    }
-
-    public static final Parcelable.Creator<Avatar> CREATOR = new Parcelable.Creator<Avatar>() {
-        public Avatar createFromParcel(Parcel source) {
-            return new Avatar(source);
-        }
-
-        public Avatar[] newArray(int size) {
-            return new Avatar[size];
-        }
-    };
 }

--- a/app/src/main/java/io/bxbxbai/zhuanlan/bean/Post.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/bean/Post.java
@@ -46,6 +46,32 @@ public class Post implements Parcelable {
     @SerializedName("likesCount")
     private int likesCount;
 
+    public static final Parcelable.Creator<Post> CREATOR = new Parcelable.Creator<Post>() {
+        public Post createFromParcel(Parcel source) {
+            return new Post(source);
+        }
+
+        public Post[] newArray(int size) {
+            return new Post[size];
+        }
+    };
+
+    public Post() {
+    }
+
+    private Post(Parcel in) {
+        this.publishedTime = in.readString();
+        this.author = in.readParcelable(Author.class.getClassLoader());
+        this.title = in.readString();
+        this.imageUrl = in.readString();
+        this.summary = in.readString();
+        this.content = in.readString();
+        this.url = in.readString();
+        this.href = in.readString();
+        this.commentsCount = in.readInt();
+        this.likesCount = in.readInt();
+    }
+
     public String getPublishedTime() {
         return publishedTime;
     }
@@ -130,29 +156,4 @@ public class Post implements Parcelable {
         dest.writeInt(this.likesCount);
     }
 
-    public Post() {
-    }
-
-    private Post(Parcel in) {
-        this.publishedTime = in.readString();
-        this.author = in.readParcelable(Author.class.getClassLoader());
-        this.title = in.readString();
-        this.imageUrl = in.readString();
-        this.summary = in.readString();
-        this.content = in.readString();
-        this.url = in.readString();
-        this.href = in.readString();
-        this.commentsCount = in.readInt();
-        this.likesCount = in.readInt();
-    }
-
-    public static final Parcelable.Creator<Post> CREATOR = new Parcelable.Creator<Post>() {
-        public Post createFromParcel(Parcel source) {
-            return new Post(source);
-        }
-
-        public Post[] newArray(int size) {
-            return new Post[size];
-        }
-    };
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed