### PR TITLE
General code quality fix-1

### DIFF
--- a/app/src/main/java/io/bxbxbai/zhuanlan/AvatarImageBehavior.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/AvatarImageBehavior.java
@@ -54,7 +54,7 @@ public class AvatarImageBehavior extends CoordinatorLayout.Behavior<CircleImageV
         float distanceXToSubtract = ((mStartXPosition - mFinalXPosition)
             * (1f - expandedPercentageFactor)) + (child.getWidth()/2);
 
-        float heightToSubtract = ((mStartHeight - finalHeight) * (1f - expandedPercentageFactor));
+        float heightToSubtract = (mStartHeight - finalHeight) * (1f - expandedPercentageFactor);
 
         child.setY(mStartYPosition - distanceYToSubtract);
         child.setX(mStartXPosition - distanceXToSubtract);
@@ -73,7 +73,7 @@ public class AvatarImageBehavior extends CoordinatorLayout.Behavior<CircleImageV
             mStartYPosition = (int) (child.getY() + (child.getHeight() / 2));
 
         if (mFinalYPosition == 0)
-            mFinalYPosition = (dependency.getHeight() /2);
+            mFinalYPosition = dependency.getHeight() /2;
 
         if (mStartHeight == 0)
             mStartHeight = child.getHeight();

--- a/app/src/main/java/io/bxbxbai/zhuanlan/utils/FastBlur.java
+++ b/app/src/main/java/io/bxbxbai/zhuanlan/utils/FastBlur.java
@@ -45,7 +45,7 @@ public class FastBlur {
         }
 
         if (radius < 1) {
-            return (null);
+            return null;
         }
 
         int w = bitmap.getWidth();
@@ -59,17 +59,17 @@ public class FastBlur {
         int wh = w * h;
         int div = radius + radius + 1;
 
-        int r[] = new int[wh];
-        int g[] = new int[wh];
-        int b[] = new int[wh];
+        int[] r = new int[wh];
+        int[] g = new int[wh];
+        int[] b = new int[wh];
         int rsum, gsum, bsum, x, y, i, p, yp, yi, yw;
-        int vmin[] = new int[Math.max(w, h)];
+        int[] vmin = new int[Math.max(w, h)];
 
         int divsum = (div + 1) >> 1;
         divsum *= divsum;
-        int dv[] = new int[256 * divsum];
+        int[] dv = new int[256 * divsum];
         for (i = 0; i < 256 * divsum; i++) {
-            dv[i] = (i / divsum);
+            dv[i] = i / divsum;
         }
 
         yw = yi = 0;
@@ -239,6 +239,6 @@ public class FastBlur {
 
         bitmap.setPixels(pix, 0, w, 0, 0, w, h);
 
-        return (bitmap);
+        return bitmap;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed